### PR TITLE
Add Discourse link to issue template contact links

### DIFF
--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Roots Discourse
+    url: https://discourse.roots.io
+    about: Is this a personal support request? Find help on our support forum.


### PR DESCRIPTION
This is a pretty cool feature: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

<img width="738" alt="Screenshot 2019-10-30 13 02 25" src="https://user-images.githubusercontent.com/6908001/67890040-8eca0500-fb15-11e9-9dda-0904d2ba4dfc.png">
