### PR TITLE
Disallow opening blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,4 @@
+blank_issues_enabled: false
 contact_links:
   - name: Roots Discourse
     url: https://discourse.roots.io


### PR DESCRIPTION
This just removes the option in the issue template selection screen. I think it’s a good default since we have the issue closer running on some projects.