### PR TITLE
fix: issue template checkbox

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,6 +13,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
+      label: Terms
       options:
         - label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,6 +13,7 @@ body:
   - type: checkboxes
     id: terms
     attributes:
+      label: Terms
       options:
         - label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
           required: true


### PR DESCRIPTION
The `label` field is required. There are [error messages emitted at the top of both the issue templates](https://github.com/roots/.github/blob/master/.github/ISSUE_TEMPLATE/bug_report.yml).
