### PR TITLE
Use dropdowns for Terms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
         4. I have seached the [Roots Discourse](https://discourse.roots.io/) for answers and followed them (if applicable)
         5. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
-        - Yes, all of the above are true.
+        - Yes, I have read the contributing guidelines, docs, and search Roots Discourse. This is not a duplicate issue or a personal support request.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
         1. I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
         2. This request is not a duplicate of an existing issue
         3. I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
-        4. I have seached the Roots Discourse for answers and followed them (if applicable)
+        4. I have seached the [Roots Discourse](https://discourse.roots.io/) for answers and followed them (if applicable)
         5. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
         - Yes, all of the above are true.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,8 @@ body:
         1. I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
         2. This request is not a duplicate of an existing issue
         3. I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
-        4. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
+        4. I have seached the Roots Discourse for answers and followed them (if applicable)
+        5. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
         - Yes, all of the above are true.
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
       required: true
 
   - type: dropdown
-    id: rtfm
+    id: not-support
     attributes:
       label: This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
       options:
-        - Yes
+        - 'Yes'
     validations:
       required: true
 
@@ -24,7 +24,7 @@ body:
     attributes:
       label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
       options:
-        - Yes
+        - 'Yes'
     validations:
       required: true
 
@@ -33,7 +33,7 @@ body:
     attributes:
       label: I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
       options:
-        - Yes
+        - 'Yes'
     validations:
       required: true
 
@@ -42,7 +42,7 @@ body:
     attributes:
       label: This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
-        - Yes
+        - 'Yes'
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
         4. I have seached the [Roots Discourse](https://discourse.roots.io/) for answers and followed them (if applicable)
         5. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
-        - Yes, I have read the contributing guidelines, docs, and search Roots Discourse. This is not a duplicate issue or a personal support request.
+        - Yes, I have read and followed the Roots contributing guidelines and relevant documentation. I have also searched Roots Discourse before posting. This is not a duplicate issue or a personal support request.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,38 +11,16 @@ body:
         If you have a question or you're looking for support, please visit [Roots Discourse](https://discourse.roots.io/).
 
   - type: dropdown
-    id: read-guidelines
+    id: terms
     attributes:
-      label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
+      label: Terms
+      description: |
+        1. I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
+        2. This request is not a duplicate of an existing issue
+        3. I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
+        4. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
-        - 'Yes'
-    validations:
-      required: true
-
-  - type: dropdown
-    id: not-a-duplicate
-    attributes:
-      label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
-      options:
-        - 'Yes'
-    validations:
-      required: true
-
-  - type: dropdown
-    id: rtfm
-    attributes:
-      label: I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
-      options:
-        - 'Yes'
-    validations:
-      required: true
-
-  - type: dropdown
-    id: not-support
-    attributes:
-      label: This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
-      options:
-        - 'Yes'
+        - Yes, all of the above are true.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,21 +10,41 @@ body:
         This form is for reporting technical issues.
         If you have a question or you're looking for support, please visit [Roots Discourse](https://discourse.roots.io/).
 
-  - type: checkboxes
-    id: terms
+  - type: dropdown
+    id: read-guidelines
     attributes:
-      label: Terms
+      label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
       options:
-        - label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
-          required: true
-        - label: This request is not a duplicate of an existing issue
-          required: true
-        - label: I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
-          required: true
-        - label: I have seached the [Roots Discourse](https://discourse.roots.io/) for answers and followed them (if applicable)
-          required: true
-        - label: This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
-          required: true
+        - Yes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: not-a-duplicate
+    attributes:
+      label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
+      options:
+        - Yes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: rtfm
+    attributes:
+      label: I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
+      options:
+        - Yes
+    validations:
+      required: true
+
+  - type: dropdown
+    id: rtfm
+    attributes:
+      label: This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
+      options:
+        - Yes
+    validations:
+      required: true
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,7 +19,7 @@ body:
         2. This request is not a duplicate of an existing issue
         3. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
-        - Yes, all of the above are true.
+        - Yes, I have read and followed the Roots contributing guidelines. This is not a duplicate issue or a personal support request.
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -17,8 +17,7 @@ body:
       description: |
         1. I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
         2. This request is not a duplicate of an existing issue
-        3. I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
-        4. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
+        3. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
         - Yes, all of the above are true.
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,17 +10,19 @@ body:
         This form is for suggesting an idea for this project.
         If you have a question or you're looking for support, please visit [Roots Discourse](https://discourse.roots.io/).
 
-  - type: checkboxes
+  - type: dropdown
     id: terms
     attributes:
       label: Terms
+      description: |
+        1. I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
+        2. This request is not a duplicate of an existing issue
+        3. I have read the [docs](https://roots.io/docs/) and followed them (if applicable)
+        4. This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
       options:
-        - label: I have read the [guidelines for Contributing to Roots Projects](https://github.com/roots/.github/blob/master/CONTRIBUTING.md)
-          required: true
-        - label: This request is not a duplicate of an existing issue
-          required: true
-        - label: This is not a personal support request that should be posted on the [Roots Discourse](https://discourse.roots.io/) community
-          required: true
+        - Yes, all of the above are true.
+    validations:
+      required: true
 
   - type: textarea
     id: summary


### PR DESCRIPTION
Resolves #2 

I’ve just added dropdowns for the bug report’s terms. If we like this, then I can add it to the feature request one as well. Also, I think I’m missing a heading for the terms.

There’s just one option for each dropdown since if there was a "no" then the field validation wouldn’t stop it from being submitted. I actually don't know if it leaves the default as blank, so this might not work.